### PR TITLE
Support updating IPv6 records on CloudFlare

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2018 boris1993
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # dnsupdater
-|master| dev |
-|:----:|:---:|
-|[![Build Status](https://travis-ci.org/boris1993/dnsupdater.svg?branch=master)](https://travis-ci.org/boris1993/dnsupdater)|[![Build Status](https://travis-ci.org/boris1993/dnsupdater.svg?branch=dev)](https://travis-ci.org/boris1993/dnsupdater)|
+[![Build Status](https://travis-ci.org/boris1993/dnsupdater.svg?branch=master)](https://travis-ci.org/boris1993/dnsupdater)
+![GitHub](https://img.shields.io/github/license/boris1993/dnsupdater)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/boris1993/dnsupdater)
+![Total download](https://img.shields.io/github/downloads/boris1993/dnsupdater/total.svg)
 
 Obtain your current external IP address and update to the specified DNS record on CloudFlare 
 

--- a/conf/config.go
+++ b/conf/config.go
@@ -28,6 +28,7 @@ type Config struct {
 // System describes the System properties in Config.yaml
 type System struct {
 	IPAddrAPI             string `yaml:"IPAddrAPI"`
+	IPv6AddrAPI           string `yaml:"IPv6AddrAPI"`
 	CloudFlareAPIEndpoint string `yaml:"CloudFlareAPIEndpoint"`
 }
 
@@ -38,6 +39,7 @@ type CloudFlare struct {
 	ZoneID     string `yaml:"ZoneID"`
 	AuthEmail  string `yaml:"AuthEmail"`
 	DomainName string `yaml:"DomainName"`
+	DomainType string `yaml:"DomainType"`
 }
 
 type AliDNS struct {
@@ -103,6 +105,7 @@ func printDebugInfo() {
 		log.Debugf("%10v: %s", "ZoneID", item.ZoneID)
 		log.Debugf("%10v: %s", "AuthEmail", item.AuthEmail)
 		log.Debugf("%10v: %s", "DomainName", item.DomainName)
+		log.Debugf("%10v: %s", "DomainType", item.DomainType)
 		log.Debugln()
 	}
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -1,16 +1,19 @@
 ---
 System:
   IPAddrAPI: "https://api.ipify.org/"
+  IPv6AddrAPI: "https://api6.ipify.org/"
   CloudFlareAPIEndpoint: "https://api.cloudflare.com/client/v4"
 CloudFlareRecords:
   - APIKey: "YOUR_CLOUDFLARE_API_KEY"
     ZoneID: "ZONE_ID_OF_YOUR_DOMAIN"
     AuthEmail: "EMAIL_FOR_LOGGING_INTO_CLOUDFLARE"
     DomainName: "FULL_DOMAIN_YOU_WANT_TO_UPDATE. e.g.:test1.example.com"
+    DomainType: "Type of this domain. A for IPv4 records, and AAAA for IPv6 records"
   - APIKey: "YOUR_CLOUDFLARE_API_KEY"
     ZoneID: "ZONE_ID_OF_YOUR_DOMAIN"
     AuthEmail: "EMAIL_FOR_LOGGING_INTO_CLOUDFLARE"
     DomainName: "FULL_DOMAIN_YOU_WANT_TO_UPDATE. e.g.:test2.example.com"
+    DomainType: "Type of this domain. A for IPv4 records, and AAAA for IPv6 records"
 AliDNSRecords:
   - AccessKeyID: "YOUR_ALIYUN_ACCESS_KEY_ID"
     AccessKeySecret: "YOUR_ALIYUN_ACCESS_KEY_SECRET"

--- a/constants/errormsg.go
+++ b/constants/errormsg.go
@@ -2,9 +2,10 @@
 package constants
 
 const MsgHeaderDNSRecordUpdateSuccessful = "Successfully updated the DNS record"
-const MsgHeaderCurrentIPAddr = "Current IP address is:"
+const MsgHeaderCurrentIPAddr = "Current IPv4 address is:"
+const MsgHeaderCurrentIPv6Addr = "Current IPv6 address is:"
 const MsgHeaderFetchingIPOfDomain = "Fetching the IP address of domain"
-const MsgHeaderLoadingConfig = "Loading configuration from"
+const MsgHeaderLoadingConfig = "Loading configurations from"
 const MsgHeaderDomainProcessing = "Processing"
 const MsgCloudFlareRecordsFoundSuffix = "CloudFlare DNS record(s) found"
 const MsgAliDNSRecordsFoundSuffix = "Aliyun DNS record(s) found"
@@ -26,3 +27,4 @@ const ErrIPAddressFetchingAPIEmpty = "API address for fetching current IP addres
 const ErrCloudFlareAPIAddressEmpty = "CloudFlare API endpoint address cannot be empty"
 const ErrCloudFlareRecordConfigIncomplete = "Incomplete CloudFlare configuration found"
 const ErrAliDNSRecordConfigIncomplete = "Incomplete Aliyun DNS configuration found"
+const ErrInvalidDomainType = "Invalid domain type. Only A and AAAA records are supported for now."

--- a/main.go
+++ b/main.go
@@ -19,20 +19,20 @@ func main() {
 	var config = conf.Get()
 
 	// Fetch the current external IP address.
-	currentIPAddress, err := getCurrentIPAddress(config)
+	ipAddress, ipv6Address, err := getCurrentIPAddress(config)
 
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	// Process CloudFlare records
-	err = cfutil.ProcessRecords(config, currentIPAddress)
+	err = cfutil.ProcessRecords(config, ipAddress, ipv6Address)
 
 	if err != nil {
 		log.Errorln(err)
 	}
 
-	alidnsutil.ProcessRecords(config, currentIPAddress)
+	alidnsutil.ProcessRecords(config, ipAddress)
 
 	os.Exit(0)
 }
@@ -53,17 +53,18 @@ func init() {
 }
 
 // getCurrentIPAddress returns the external IP address for your network
-func getCurrentIPAddress(config conf.Config) (string, error) {
-	if config.System.IPAddrAPI == "" {
-		return "", errors.New(constants.ErrIPAddressFetchingAPIEmpty)
+func getCurrentIPAddress(config conf.Config) (string, string, error) {
+	if config.System.IPAddrAPI == "" || config.System.IPv6AddrAPI == "" {
+		return "", "", errors.New(constants.ErrIPAddressFetchingAPIEmpty)
 	}
 
 	log.Println(constants.MsgCheckingCurrentIPAddr)
 
+	//region fetch your IPv4 address
 	resp, err := http.Get(config.System.IPAddrAPI)
 
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// Handle errors when closing the HTTP connection
@@ -78,13 +79,39 @@ func getCurrentIPAddress(config conf.Config) (string, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// Body only contains the IP address
 	ipAddress := string(body)
+	//endregion
+
+	//region fetch your IPv6 address
+	resp, err = http.Get(config.System.IPv6AddrAPI)
+
+	if err != nil {
+		return "", "", err
+	}
+
+	defer func() {
+		err := resp.Body.Close()
+
+		if err != nil {
+			log.Errorln(constants.ErrCloseHTTPConnectionFail, err)
+		}
+	}()
+
+	body, err = ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return "", "", err
+	}
+
+	ipv6Address := string(body)
+	//endregion
 
 	log.Println(constants.MsgHeaderCurrentIPAddr, ipAddress)
+	log.Println(constants.MsgHeaderCurrentIPv6Addr, ipv6Address)
 
-	return ipAddress, nil
+	return ipAddress, ipv6Address, nil
 }


### PR DESCRIPTION
Support updating IPv6 records for fixing issue #44 

Known bugs:
- Addresses with leading zeros(e.g. `2001:0db8:0000:0000:0000:ff00:0042:8329`) and without leading zeros(e.g. `2001:db8:0:0:0:ff00:42:8329`) will be treated as different addresses.
- Addresses with consecutive sections of zeros(e.g. `2001:0db8:0000:0000:0000:ff00:0042:8329`) and without consecutive sections of zeros(e.g. `2001:db8::ff00:42:8329`) will be treated as different addresses.